### PR TITLE
Use 4.6.1 framework

### DIFF
--- a/build/targets/Microsoft.VisualStudio.Debugger.VSCodeDebugAdapterHost.CSharp.Settings.targets
+++ b/build/targets/Microsoft.VisualStudio.Debugger.VSCodeDebugAdapterHost.CSharp.Settings.targets
@@ -9,7 +9,7 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.6.1</TargetFrameworkVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <!-- Microbuild's build pool currently only supports Dev14. -->


### PR DESCRIPTION
Switch from 4.6.2 to 4.6.1, as that's what is installed by default with
VS.