### PR TITLE
Update samples to work with VS 2022

### DIFF
--- a/build/targets/Microsoft.VisualStudio.Debugger.VSCodeDebugAdapterHost.Core.Settings.targets
+++ b/build/targets/Microsoft.VisualStudio.Debugger.VSCodeDebugAdapterHost.Core.Settings.targets
@@ -21,7 +21,7 @@
   <!-- VSSDK Information -->
   <PropertyGroup>
     <VisualStudioVersion>15.0</VisualStudioVersion>
-    <VSSDKPackageVersion>15.5.72</VSSDKPackageVersion>
+    <VSSDKPackageVersion>17.2.2186</VSSDKPackageVersion>
   </PropertyGroup>
   <Import Project="$(NugetPackageRoot)Microsoft.VSSDK.BuildTools.$(VSSDKPackageVersion)\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('$(NugetPackageRoot)Microsoft.VSSDK.BuildTools.$(VSSDKPackageVersion)\build\Microsoft.VSSDK.BuildTools.props')" />
 

--- a/src/sample/SampleDebugAdapter.VSIX/SampleDebugAdapter.VSIX.csproj
+++ b/src/sample/SampleDebugAdapter.VSIX/SampleDebugAdapter.VSIX.csproj
@@ -50,8 +50,8 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <VSIXSubPath>adapter</VSIXSubPath>
     </ProjectReference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$(NugetPackageRoot)Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>$(NugetPackageRoot)Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
       <!-- JSON.Net is normally excluded from packaging in VSIXes because the VS assembly resolver will
            redirect to the version shipped with VS, but we need a copy for SampleDebugAdapter.exe. -->

--- a/src/sample/SampleDebugAdapter.VSIX/packages.config
+++ b/src/sample/SampleDebugAdapter.VSIX/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.5.72" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
+  <package id="Microsoft.VSSDK.BuildTools" version="17.2.2186" targetFramework="net461" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="15.6.20118.1" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.Debugger.DebugAdapterHost.Interfaces" version="15.6.20118.1" targetFramework="net462" />

--- a/src/sample/SampleDebugAdapter.VSIX/source.extension.vsixmanifest
+++ b/src/sample/SampleDebugAdapter.VSIX/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
         <Description xml:space="preserve">Packaging project for SampleDebugAdapter, demonstrating registration with VS and the Debug Adapter Host.</Description>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -14,10 +14,10 @@
     <Assets>
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="SampleDebugAdapter" Path="|SampleDebugAdapter|" AssemblyName="|SampleDebugAdapter;AssemblyName|" d:VsixSubPath="adapter" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="AdapterRegistration.pkgdef" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" d:VsixSubPath="adapter" />
+        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" d:VsixSubPath="adapter" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Debugger.JustInTime" Version="[15.0,16.0)" DisplayName="Just-In-Time debugger" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Debugger.JustInTime" Version="[15.0,)" DisplayName="Just-In-Time debugger" />
     </Prerequisites>
 </PackageManifest>

--- a/src/sample/SampleDebugAdapter/App.config
+++ b/src/sample/SampleDebugAdapter/App.config
@@ -3,4 +3,15 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral" />
+        <bindingRedirect oldVersion="8.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/sample/SampleDebugAdapter/SampleDebugAdapter.csproj
+++ b/src/sample/SampleDebugAdapter/SampleDebugAdapter.csproj
@@ -18,8 +18,8 @@
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(NugetPackageRoot)Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.15.6.20118.1\lib\net45\Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$(NugetPackageRoot)Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>$(NugetPackageRoot)Newtonsoft.Json.13.0.0\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ookii.CommandLine, Version=2.2.0.0, Culture=neutral, PublicKeyToken=0c15020868fd6249, processorArchitecture=MSIL">
       <HintPath>$(NugetPackageRoot)Ookii.CommandLine.2.2\lib\Ookii.CommandLine.dll</HintPath>

--- a/src/sample/SampleDebugAdapter/packages.config
+++ b/src/sample/SampleDebugAdapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="15.6.20118.1" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="Ookii.CommandLine" version="2.2" targetFramework="net461" />
 </packages>

--- a/src/tools/EngineLauncher/packages.config
+++ b/src/tools/EngineLauncher/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net461" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.5.72" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="17.2.2186" targetFramework="net461" developmentDependency="true" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net461" />
   <package id="VSSDK.DTE.8" version="8.0.4" targetFramework="net461" />
 </packages>

--- a/src/tools/EngineLauncher/source.extension.vsixmanifest
+++ b/src/tools/EngineLauncher/source.extension.vsixmanifest
@@ -10,10 +10,9 @@
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
     


### PR DESCRIPTION
This updates the samples to build against the latest version of the
VSSDK, which supports VS 2022.  It also updates to the latest version of
Newtonsoft.Json.